### PR TITLE
Fix broken link to screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A processing pipeline for PALM movies analysis (pre-processing, localization, dr
 
 Check out the [documentation] to get started.
 
-![napari_plugin](docs/images/plugin_steps.png "Fine-tune your pipelines on a movie, run it on a batch easily !")
+![napari_plugin](https://github.com/hippover/palmari/raw/main/docs/images/plugin_steps.png "Fine-tune your pipelines on a movie, run it on a batch easily !")
 
 ----------------------------------
 


### PR DESCRIPTION
Hi @hippover ,

this PR fixes that screenshots are not shown on the [napari-hub page of your plugin](https://www.napari-hub.org/plugins/palmari). To make them view, we need to use absolute links. Furthermore, after merging this, you need to create a new release on pypi to update the napari-hub page.

Let me know if there is anything!

Best,
Robert